### PR TITLE
Fixed flaky test testIdWithJaxbRules(), in TestXmlID2.java 

### DIFF
--- a/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/id/TestXmlID2.java
+++ b/jaxb/src/test/java/com/fasterxml/jackson/module/jaxb/id/TestXmlID2.java
@@ -137,11 +137,12 @@ public class TestXmlID2 extends BaseJaxbTest
         ObjectMapper mapper = new ObjectMapper();
         // but then also variant where ID is ALWAYS used for XmlID / XmlIDREF
         mapper.setAnnotationIntrospector(new JaxbAnnotationIntrospector(mapper.getTypeFactory()));
+        mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
         List<User> users = getUserList();
         final String json = mapper.writeValueAsString(users);
-        String expected = "[{\"id\":11,\"username\":\"11\",\"email\":\"11@test.com\",\"department\":9}"
-                +",{\"id\":22,\"username\":\"22\",\"email\":\"22@test.com\",\"department\":9}"
-                +",{\"id\":33,\"username\":\"33\",\"email\":\"33@test.com\",\"department\":null}]";
+        String expected = "[{\"id\":11,\"department\":9,\"email\":\"11@test.com\",\"username\":\"11\"}"
+                          +",{\"id\":22,\"department\":9,\"email\":\"22@test.com\",\"username\":\"22\"}"
+                          +",{\"id\":33,\"department\":null,\"email\":\"33@test.com\",\"username\":\"33\"}]";
         
         assertEquals(expected, json);
 


### PR DESCRIPTION
Method `testIdWithJaxbRules()` was flaky when test using NonDex tool. The root cause is that when calling `writeValueAsString()` method on an `ObjectMapper`, the string generated is nondeterministic. However, the method `writeValueAsString()` was from a third party. So I fixed this in the test mothod by configuring the `ObjectMapper` to sort the items in it in alphabetical order, using `configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)`. Then the result of `writeValueAsString()` is no longer nondeterministic, but it's stably wrong. Finally, I changed the hardcoded expected value in the test class to an alphabetical order so that the test case will always succeed.